### PR TITLE
Refactor

### DIFF
--- a/examples/test-app/views/SelectionButtons.html
+++ b/examples/test-app/views/SelectionButtons.html
@@ -112,10 +112,14 @@
 
   <div class="panel panel-border-wide">
     {{ header('Code', size='small') }}
-    <pre><code>{% raw %}{{ selectionButtons(field, "A question",
-  hideQuestion = true,
+    <pre><code>{% raw %}{{ selectionButtons(field, "Which types of waste do you transport regularly?",
+  hideQuestion = false,
+  hint = 'Select all that apply',
+  type = 'checkbox',
   options = [
-    { label: "Isle of Man or the Channel Islands", disabled: true }
+    { label: "Waste from animal carcasses", value: 'animal' },
+    { label: "Waste from mines or quarries", value: 'mines' },
+    { label: "Farm or agricultural waste", value: 'agriculture' }
   ]
 ) }}{% endraw %}</code></pre>
   </div>

--- a/src/sources/govukTemplate.js
+++ b/src/sources/govukTemplate.js
@@ -18,5 +18,5 @@ const copyGovukTemplateAssets = new CopyWebpackPlugin([
 
 module.exports = {
   paths: { root, templates, assets, images, javascripts, stylesheets },
-  plugins: [ copyGovukTemplateAssets ]
+  copyGovukTemplateAssets
 };

--- a/src/sources/govukToolkit.js
+++ b/src/sources/govukToolkit.js
@@ -14,5 +14,5 @@ const copyGovukToolkitAssets = new CopyWebpackPlugin([
 
 module.exports = {
   paths: { root, sass },
-  plugins: [ copyGovukToolkitAssets ]
+  copyGovukToolkitAssets
 };

--- a/src/webpack.js
+++ b/src/webpack.js
@@ -17,7 +17,7 @@ const webpackSettings = (_assetPath, settings) => {
     plugins: [
       _scss.extractSassIntoFiles,
       govukTemplate.copyGovukTemplateAssets,
-      ...govukToolkit.plugins
+      govukToolkit.copyGovukToolkitAssets
     ],
     module: { rules: [ _scss.scssLoader ] },
     resolve: {

--- a/src/webpack.js
+++ b/src/webpack.js
@@ -15,12 +15,17 @@ const webpackSettings = (_assetPath, settings) => {
 
   const defaults = {
     plugins: [
-      ..._scss.plugins,
+      _scss.extractSassIntoFiles,
       ...govukTemplate.plugins,
       ...govukToolkit.plugins
     ],
-    module: { rules: [..._scss.rules] },
-    resolve: { alias: Object.assign({}, govukElements.alias) }
+    module: { rules: [ _scss.scssLoader ] },
+    resolve: {
+      alias: Object.assign(
+        {},
+        govukElements.alias
+      )
+    }
   };
   return Object.assign({}, defaults, settings);
 };

--- a/src/webpack.js
+++ b/src/webpack.js
@@ -16,7 +16,7 @@ const webpackSettings = (_assetPath, settings) => {
   const defaults = {
     plugins: [
       _scss.extractSassIntoFiles,
-      ...govukTemplate.plugins,
+      govukTemplate.copyGovukTemplateAssets,
       ...govukToolkit.plugins
     ],
     module: { rules: [ _scss.scssLoader ] },

--- a/src/webpack/rules/scss.js
+++ b/src/webpack/rules/scss.js
@@ -2,7 +2,7 @@ const ExtractTextPlugin = require('extract-text-webpack-plugin');
 const govukElements = require('../../sources/govukElements');
 const govukToolkit = require('../../sources/govukToolkit');
 
-const extractSass = new ExtractTextPlugin({ filename: '[name].css' });
+const extractSassIntoFiles = new ExtractTextPlugin({ filename: '[name].css' });
 
 const sass = assetPath => {
   const sassLoader = {
@@ -17,12 +17,12 @@ const sass = assetPath => {
       /* eslint-enable id-blacklist */
     }
   };
-  const scssRule = {
+  const scssLoader = {
     test: /\.scss$/,
-    use: extractSass.extract(['css-loader', sassLoader])
+    use: extractSassIntoFiles.extract(['css-loader', sassLoader])
   };
 
-  return { rules: [scssRule], plugins: [extractSass] };
+  return { scssLoader, extractSassIntoFiles };
 };
 
 module.exports = sass;


### PR DESCRIPTION
This PR makes a few small refactors to naming in the webpack module that makes it slightly easier to understand. Before with `...govukTemplate.plugins` it was hard to understand what those plugins did, now with `govukTemplate.copyGovukTemplateAssets` it's clearer from reading that it will copy the template assets in to the webpack bundle.