### PR TITLE
Prevent outputting of undefined field values

### DIFF
--- a/templates/look-and-feel/components/fields.njk
+++ b/templates/look-and-feel/components/fields.njk
@@ -23,7 +23,7 @@
          id="{{ field.id }}"
          name="{{ field.id }}"
          type="text"
-         value="{{ field.value }}">
+         value="{{ field.value if field.value }}">
 </div>
 {% endmacro %}
 


### PR DESCRIPTION
If a field value is `undefined` then outputting it can lead to unexpected behaviour, including outputting `"undefined"` or `""` which will cause the posted value to be an empty string and not the correct `undefined`. 

This PR fixes this by only rendering the `value=...` part of a text field if the field has a value.