### PR TITLE
Never output undefined

### DIFF
--- a/templates/look-and-feel/components/fields.njk
+++ b/templates/look-and-feel/components/fields.njk
@@ -23,7 +23,7 @@
          id="{{ field.id }}"
          name="{{ field.id }}"
          type="text"
-         value="{{ field.value if field.value }}">
+         {% if field.value %}value="{{ field.value }}"{% endif %}>
 </div>
 {% endmacro %}
 


### PR DESCRIPTION
Prevent outputting `value=''` if field.value is undefined