### PR TITLE
Fix typo in the class for the one third column in two-thirds.html

### DIFF
--- a/templates/look-and-feel/layouts/two_thirds.html
+++ b/templates/look-and-feel/layouts/two_thirds.html
@@ -8,7 +8,7 @@
     <div class="column-two-thirds">
       {% block two_thirds -%}{%- endblock %}
     </div>
-    <div class="column-one-thirds">
+    <div class="column-one-third">
       {% block one_third -%}{%- endblock %}
     </div>
   </div>


### PR DESCRIPTION
This fix is to match the class with what is used in govuk elements. 
As this class does not match what is in govuk, no styling is added.
When the correct class is added, we get the correct css added to the div which includes:
- float: left, 
- width: 33%
- padding-left: 15px