### PR TITLE
Allow usage of webpack dev middleware outside of development

### DIFF
--- a/examples/test-app/yarn.lock
+++ b/examples/test-app/yarn.lock
@@ -3,7 +3,7 @@
 
 
 "@hmcts/look-and-feel@./../../":
-  version "1.0.2"
+  version "1.1.1"
   dependencies:
     babel-core "^6.26.0"
     babel-loader "^7.1.2"
@@ -12,6 +12,7 @@
     config "^1.26.1"
     copy-webpack-plugin "^4.0.1"
     css-loader "^0.28.4"
+    deepmerge "^2.0.0"
     diff-so-fancy "^1.1.1"
     exports-loader "^0.6.4"
     express "^4.15.3"
@@ -25,7 +26,7 @@
     node-sass "^4.5.3"
     nunjucks "^3.0.1"
     sass-loader "^6.0.6"
-    style-loader "^0.18.2"
+    style-loader "^0.19.0"
     webpack "^3.4.1"
     webpack-dev-middleware "^1.12.0"
 
@@ -1331,6 +1332,10 @@ decamelize@^1.0.0, decamelize@^1.1.1, decamelize@^1.1.2:
 deep-extend@~0.4.0:
   version "0.4.2"
   resolved "https://registry.yarnpkg.com/deep-extend/-/deep-extend-0.4.2.tgz#48b699c27e334bf89f10892be432f6e4c7d34a7f"
+
+deepmerge@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/deepmerge/-/deepmerge-2.0.1.tgz#25c1c24f110fb914f80001b925264dd77f3f4312"
 
 defined@^1.0.0:
   version "1.0.0"
@@ -3990,9 +3995,9 @@ strip-json-comments@~2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-2.0.1.tgz#3c531942e908c2697c0ec344858c286c7ca0a60a"
 
-style-loader@^0.18.2:
-  version "0.18.2"
-  resolved "https://registry.yarnpkg.com/style-loader/-/style-loader-0.18.2.tgz#cc31459afbcd6d80b7220ee54b291a9fd66ff5eb"
+style-loader@^0.19.0:
+  version "0.19.0"
+  resolved "https://registry.yarnpkg.com/style-loader/-/style-loader-0.19.0.tgz#7258e788f0fee6a42d710eaf7d6c2412a4c50759"
   dependencies:
     loader-utils "^1.0.2"
     schema-utils "^0.3.0"

--- a/src/development.js
+++ b/src/development.js
@@ -1,0 +1,21 @@
+const isDev = require('./util/isDev');
+const webpackDev = require('webpack-dev-middleware');
+
+const setupDevMiddleware = (app, settings) => {
+  const _webpack = app.get('webpack');
+
+  const defaultSettings = { publicPath: '/assets/' };
+
+  app.use(webpackDev(_webpack, Object.assign(defaultSettings, settings)));
+};
+
+const configureDevelopment = (app, {
+  useWebpackDevMiddleware = false,
+  webpackDevMiddleware
+} = {}) => {
+  if (isDev() || useWebpackDevMiddleware) {
+    setupDevMiddleware(app, webpackDevMiddleware);
+  }
+};
+
+module.exports = { configureDevelopment };

--- a/src/main.js
+++ b/src/main.js
@@ -1,7 +1,9 @@
 const { configureViews } = require('./views');
 const { configureNunjucks } = require('./nunjucks');
 const { configureWebpack } = require('./webpack');
+const { configureDevelopment } = require('./development');
 const { assigned } = require('check-types');
+const url = require('url');
 
 const expressDefaults = { views: [] };
 
@@ -9,13 +11,17 @@ const configure = (app, {
   baseUrl,
   express = expressDefaults,
   nunjucks = {},
-  webpack = {}
+  webpack = {},
+  development = {}
 } = {}) => {
   if (!assigned(baseUrl)) throw Error('baseUrl not defined');
+
+  app.set('assetPath', url.resolve(baseUrl, 'assets/'));
 
   configureViews(app, express.views);
   configureNunjucks(app, nunjucks);
   configureWebpack(app, baseUrl, webpack);
+  configureDevelopment(app, development);
 
   return app;
 };

--- a/src/nunjucks.js
+++ b/src/nunjucks.js
@@ -13,6 +13,7 @@ const nunjucksDefaults = {
 };
 
 const configureNunjucks = (app, settings) => {
+  app.locals.asset_path = app.get('assetPath');
   nunjucks(app, Object.assign({}, nunjucksDefaults, settings));
   return app;
 };

--- a/src/webpack.js
+++ b/src/webpack.js
@@ -1,15 +1,9 @@
-const url = require('url');
-const webpackDev = require('webpack-dev-middleware');
 const webpack = require('webpack');
-const isDev = require('./util/isDev');
-
 const scss = require('./webpack/rules/scss');
 const browserSupport = require('./webpack/rules/browserSupport');
 const govukTemplate = require('./sources/govukTemplate');
 const govukElements = require('./sources/govukElements');
 const govukToolkit = require('./sources/govukToolkit');
-
-const assetPath = baseUrl => url.resolve(baseUrl, 'assets/');
 
 const isDefined = obj => typeof obj !== 'undefined';
 const defaultIfUndefined = (obj, _default) => {
@@ -19,8 +13,8 @@ const defaultIfUndefined = (obj, _default) => {
   return _default;
 };
 
-const webpackSettings = (_assetPath, settings) => {
-  const _scss = scss(_assetPath);
+const webpackSettings = (assetPath, settings) => {
+  const _scss = scss(assetPath);
   const userModules = defaultIfUndefined(settings.module, {});
   const userRules = defaultIfUndefined(userModules.rules, []);
   const userResolve = defaultIfUndefined(settings.resolve, {});
@@ -65,17 +59,13 @@ const webpackSettings = (_assetPath, settings) => {
   return Object.assign({}, defaults, settings, manualMerged);
 };
 
-const setupDevMiddleware = (app, _assetPath, settings) => {
-  const _webpack = webpack(webpackSettings(_assetPath, settings));
-  app.use(webpackDev(_webpack, { publicPath: '/assets/' }));
-};
-
 const configureWebpack = (app, baseUrl, settings) => {
-  app.locals.asset_path = assetPath(baseUrl);
+  const assetPath = app.get('assetPath');
+  const _webpackSettings = webpackSettings(assetPath, settings);
+  const _webpack = webpack(_webpackSettings);
 
-  if (isDev()) {
-    setupDevMiddleware(app, assetPath(baseUrl), settings);
-  }
+  app.set('webpackSettings', _webpackSettings);
+  app.set('webpack', _webpack);
 
   return app;
 };


### PR DESCRIPTION
**Not recommended for production**

Until a proper asset management scheme is put in place for Reform (for tactical this will never happen) we need a way to use the webpack dev middleware without needing to set NODE_ENV to development. This PR makes that change.

To use the webpack dev middleware either have your `NODE_ENV = development` or:
```
lookAndFeel.configure(app, {
  development: {
    useWebpackDevMiddleware: true,
    webpackDevMiddleware: {
      // override default dev middleware settings
    }
  }
});
```

Check the [documentation on the webpack dev middleware](https://github.com/webpack/webpack-dev-middleware) for the available settings that can be overridden. 

--------

This PR also makes a few changes to make working with webpack easier:
- the webpack settings are now accessible after configuration via `app.get('webpackSettings')`
- the webpack instance is now accessible after configuration via `app.get('webpack')`

This will allow users of look and feel write a script that tells webpack to generate the assets in to a bundle:

**app.js**
```
const app = express();
lookAndFeel.configure(app, { ... });
module.exports = { app };
```

**server.js**
```
const { app } = require('./app');
app.listen(3000);
```

**setup.js**
```
const { app } = require('./app');
const webpack = app.get('webpack');
webpack.run();
```