### PR TITLE
Support merging of globals

### DIFF
--- a/src/nunjucks.js
+++ b/src/nunjucks.js
@@ -29,7 +29,9 @@ const nunjucksDefaults = {
 
 const configureNunjucks = (app, settings) => {
   app.locals.asset_path = app.get('assetPath');
-  nunjucks(app, Object.assign({}, nunjucksDefaults, settings));
+
+  const globals = Object.assign({}, nunjucksDefaults.globals, settings.globals);
+  nunjucks(app, Object.assign({}, nunjucksDefaults, settings, { globals }));
   return app;
 };
 


### PR DESCRIPTION
This PR improves how we set globals by merging with globals set by the user. This way the globals we set will not need set again if a user wants to set common template globals like service name or feedback url.
