### PR TITLE
Add a macro for propositional navigation

### DIFF
--- a/templates/look-and-feel/components/nav.njk
+++ b/templates/look-and-feel/components/nav.njk
@@ -1,0 +1,31 @@
+{#
+  propositionalNavigation
+    serviceName   - (required) the service name to display
+    link          - (default = []) links to display under the service name
+    options.label - (required) the label to display for the link
+    options.href  - (required) the url the link should point to
+
+  renders a propositional navigation including a service name and optional
+  links to parts of the service.
+#}
+
+{% macro propositionalNavigation(serviceName, links) %}
+  <div class="header-proposition">
+    <div class="content">
+      <a href="#proposition-links" class="js-header-toggle menu">Menu</a>
+      <nav id="proposition-menu">
+        <a href="/" id="proposition-name">
+          {{ serviceName | default('No serviceName given') }}
+        </a>
+
+        {% if isArray(links) %}
+          <ul id="proposition-links">
+            {% for link in links %}
+              <li><a href="{{ link.href }}">{{ link.label }}</a></li>
+            {% endfor %}
+          </ul>
+        {% endif %}
+      </nav>
+    </div>
+  </div>
+{% endmacro %}


### PR DESCRIPTION
This PR adds a macro for rendering a propositional nav. 

**Service name**

```
{% from "look-and-feel/components/nav.njk" import propositionalNavigation %}

{% block proposition_header %}
  {{ propositionalNavigation('Apply for Divorce') }}
{% endblock %}
```
will output: 
![image](https://user-images.githubusercontent.com/1446145/33390069-bb99daee-d52c-11e7-9df3-fe36074bc758.png)

**Service name with links**

```
{% from "look-and-feel/components/nav.njk" import propositionalNavigation %}

{% block proposition_header %}
  {{ propositionalNavigation('Apply for Divorce',
    links = [
      { href: '/foo', label: 'Foo' },
      { href: '/bar', label: 'Bar' }
    ]
  ) }}
{% endblock %}
```
![image](https://user-images.githubusercontent.com/1446145/33390278-55e82dc6-d52d-11e7-9c3d-80a1c166571c.png)

*note* when using this macro it's important to set the `with-proposition` class on the header, otherwise spacing will be totally messed up:

```
{% block header_class %}
  with-proposition
{% endblock %}
```