### PR TITLE
Additional classes to the textbox macro

### DIFF
--- a/templates/look-and-feel/components/fields.njk
+++ b/templates/look-and-feel/components/fields.njk
@@ -3,10 +3,11 @@
     field - (required) A field object containing name, id and value
     label - (required) The label to apply to the field
     hint  - (default = '') Extra hint text to place under the label
+    class - (default = '') Additional classes to add to the text input
 
   Renders a simple text box input field.
 #}
-{% macro textbox(field, label, hint=false) %}
+{% macro textbox(field, label, hint=false, class='') %}
 <div class="form-group {{ errorClass(field) }}">
 
   <label class="form-label"
@@ -19,7 +20,7 @@
     {%- endif %}
   </label>
   {{ errorsFor(field) }}
-  <input class="form-control"
+  <input class="form-control {{ class }}"
          id="{{ field.id }}"
          name="{{ field.id }}"
          type="text"


### PR DESCRIPTION
SSCS have a need to pass classes to the text input in order to change the size of the textbox. This PR covers this.

- Add an optional parameter called class to the textbox macro in `fields.njk`
- Use the parameter in the text input element
- This should work for a single class or multiple classes 
e.g. `textbox(field, label, hint='', class='class-one class-two class-three')`