### PR TITLE
Add a date component

### DIFF
--- a/templates/look-and-feel/components/fields.njk
+++ b/templates/look-and-feel/components/fields.njk
@@ -184,6 +184,64 @@
 {% endmacro %}
 
 
+{% macro date(field, question, hint='', hideQuestion=false, labels={}) %}
+<fieldset
+  id="{{ field.id }}"
+  class="form-group form-date {{ errorClass(field) }}{{ errorClass(field.day) }}{{ errorClass(field.month) }}{{ errorClass(field.year) }}">
+
+  {% if not hideQuestion %}
+    <legend class="form-label-bold">{{ question | safe }}</legend>
+  {% endif %}
+
+  {% if hint %}
+    <span class="form-hint">{{ hint | safe }}</span>
+  {% endif %}
+
+  {{ errorsFor(field) }}
+  {{ errorsFor(field.day) }}
+  {{ errorsFor(field.month) }}
+  {{ errorsFor(field.year) }}
+
+  <div class="form-group form-group-day">
+    <label for="{{ field.day.id }}">{{ labels.day | default('Day') }}</label>
+    <input class="form-control {{ errorClass(field.day, 'control') }} {{ errorClass(field, 'control') }}"
+           id="{{ field.day.id }}"
+           type="number"
+           pattern="[0-9]*"
+           min="1"
+           max="31"
+           name="{{ field.day.id }}"
+           {% if field.day.value %}value="{{ field.day.value }}"{% endif %}>
+  </div>
+
+  <div class="form-group form-group-month">
+    <label for="{{ field.month.id }}">{{ labels.month | default('Month') }}</label>
+    <input class="form-control {{ errorClass(field.month, 'control') }} {{ errorClass(field, 'control') }}"
+           id="{{ field.month.id }}"
+           type="number"
+           pattern="[0-9]*"
+           min="1"
+           max="12"
+           name="{{ field.month.id }}"
+           {% if field.month.value %}value="{{ field.month.value }}"{% endif %}>
+  </div>
+
+  <div class="form-group form-group-year">
+    <label for="{{ field.year.id }}">{{ labels.year | default('Year') }}</label>
+    <input class="form-control {{ errorClass(field.year, 'control') }} {{ errorClass(field, 'control') }}"
+           id="{{ field.year.id }}"
+           type="number"
+           pattern="[0-9]*"
+           min="1"
+           name="{{ field.year.id }}"
+           {% if field.year.value %}value="{{ field.year.value }}"{% endif %}>
+  </div>
+
+</fieldset>
+
+{% endmacro %}
+
+
 {% macro errorsFor(field) -%}
   {% if field.errors %}
   {% for error in field.errors -%}
@@ -194,8 +252,8 @@
   {% endif %}
 {%- endmacro %}
 
-{% macro errorClass(field) -%}
+{% macro errorClass(field, type='group') -%}
   {% if field.errors and field.errors|length > 0 %}
-    form-group-error
+    form-{{ type }}-error
   {% endif %}
 {%- endmacro %}


### PR DESCRIPTION
This PR adds a component to represent the common date text boxes used to collect a date from a user.

![image](https://user-images.githubusercontent.com/1446145/33835743-5b837e38-de7f-11e7-9115-a03582c30d07.png)

```
{{ date(fields.date, 'When did you get married?',
  hint = 'For example, 11 12 2017',
  labels = {
    day: 'Day',
    month: 'Month',
    year: 'Year'
  }
) }}
```
