### PR TITLE
Overwrite phasebanner html

### DIFF
--- a/templates/look-and-feel/components/phase_banner.njk
+++ b/templates/look-and-feel/components/phase_banner.njk
@@ -4,13 +4,26 @@
     feedbackLink - (default = '#') Link to feedback form
 
   Renders a phase banner. If phase is "LIVE" the banner will not be rendered.
+
+  If called the call block will replace the banner content:
+  ```
+  {% call phaseBanner('ALPHA') %}
+  This service is in Alpha.
+  {% endcall %}
+  ```
 #}
 {% macro phaseBanner(phase='ALPHA', feedbackLink='#') %}
 {% if phase != 'LIVE' %}
 <div class="phase-banner">
   <p>
     <strong class="phase-tag">{{ phase }}</strong>
-    <span>This is a new service – your <a href="{{ feedbackLink }}">feedback</a> will help us to improve it.</span>
+    <span>
+    {% if caller %}
+      {{ caller() }}
+    {% else %}
+      This is a new service – your <a href="{{ feedbackLink }}">feedback</a> will help us to improve it.
+    {% endif %}
+    </span>
   </p>
 </div>
 {% endif %}


### PR DESCRIPTION
- SSCS Submit your appeal have a requirement to overwrite the default phase-banner content and also to be able to open the feedback link in a new tab.
- Change the phase-banner component in order to pass in our own html to the macro.
- If html is not passed to the macro (and therefore null), then use the `defaultText` variable content and link. 