### PR TITLE
Allow services to override content on Check your answers

### DIFF
--- a/templates/look-and-feel/layouts/check_your_answers.html
+++ b/templates/look-and-feel/layouts/check_your_answers.html
@@ -4,17 +4,25 @@
 {% from "look-and-feel/components/phase_banner.njk" import phaseBanner %}
 {% from "look-and-feel/components/fields.njk" import hiddenInput %}
 
-{% block page_title %}{{ title | default('Check your answers') }}{% endblock %}
+{% set defaultContent = {
+  title: 'Check your answers',
+  incompleteHeader: 'Your application is incomplete',
+  incompleteMessage: 'There are still some questions to answer.',
+  continue: 'Continue your application',
+  statementOfTruth: 'By submitting this notification you are confirming that, to the best of your knowledge, the details you are providing are correct.',
+  sendApplication: 'Send your application'
+} %}
+
+{% block page_title %}{{ pageContent.title | default(defaultContent.title) }}{% endblock %}
 
 {% block breadcrumbs %}
 {{ phaseBanner(phase, feedbackLink) }}
 <a class="link-back" href="#" onclick="history.go(-1); return false;">Back</a>
 {% endblock %}
 
-
 {% block two_thirds %}
 
-{{ header(title | default('Check your answers')) }}
+{{ header(pageContent.title | default(defaultContent.title)) }}
 
   {% for section in _sections %}
 
@@ -39,19 +47,16 @@
 
   {% if incomplete %}
     {% block continue_application %}
-      {{ header('Your application is incomplete', size='medium') }}
-      <p>There are still some questions to answer.</p>
-      <a href="{{ continueUrl }}" class="button">Continue your application</a>
+      {{ header(pageContent.incompleteHeader | default(defaultContent.incompleteHeader), size='medium') }}
+      <p>{{ pageContent.incompleteMessage | default(defaultContent.incompleteMessage) }}</p>
+      <a href="{{ continueUrl }}" class="button">{{ pageContent.continue | default(defaultContent.continue) }}</a>
     {% endblock %}
   {% endif %}
 
   {% if complete %}
     {% block statement_of_truth_content %}
       {{ header('Now send your application', size='medium') }}
-      <p>
-        By submitting this notification you are confirming that, to the best of
-        your knowledge, the details you are providing are correct.
-      </p>
+      <p>{{ pageContent.statementOfTruth | default(defaultContent.statementOfTruth) }}</p>
     {% endblock %}
     <form action="{{ path if path else url }}" method="post" class="form">
 
@@ -59,7 +64,7 @@
         {{ hiddenInput(fields.statementOfTruth, value=true) }}
       {%- endblock %}
 
-      <input class="button" type="submit" value="Continue">
+      <input class="button" type="submit" value="{{ pageContent.sendApplication | default(defaultContent.sendApplication) }}">
     </form>
   {% endif %}
 


### PR DESCRIPTION
In order to customise check your answers developers need a flexible way to set the content.

This PR takes the content out of the template and uses a `pageContent` variable to allow the user to set the content.

To override a content line you set it as:
```
{% set pageContent = {
  title: 'Custom title'
} %}
```

This will only override that single key, all other keys will maintain their defaults.