### PR TITLE
Error summary above heading

### DIFF
--- a/templates/look-and-feel/layouts/check_your_answers.html
+++ b/templates/look-and-feel/layouts/check_your_answers.html
@@ -23,9 +23,9 @@
 
 {% block two_thirds %}
 
-{{ header(pageContent.title | default(defaultContent.title)) }}
+{{ errorSummary(fields) }}
 
-  {{ errorSummary(fields) }}
+{{ header(pageContent.title | default(defaultContent.title)) }}
 
   {% for section in _sections %}
 

--- a/templates/look-and-feel/layouts/question.html
+++ b/templates/look-and-feel/layouts/question.html
@@ -12,11 +12,11 @@
 
 {% block two_thirds %}
 
+{{ errorSummary(fields) }}
+
 {{ header(title, size='large') }}
 
 <form action="{{ postUrl | default(path if path else url) }}" method="post" class="form">
-
-  {{ errorSummary(fields) }}
 
   {% block fields -%}
   {%- endblock %}


### PR DESCRIPTION
- The error summary should be above the header on the page according to GDS guidelines
- Move the error summary above the header for the question template
- Move the error summary above the header for the check your appeal template