### PR TITLE
Ensure govuk modules import the actual window

### DIFF
--- a/src/sources/govukToolkit.js
+++ b/src/sources/govukToolkit.js
@@ -20,7 +20,8 @@ const govukModule = (file, expose, imports = ['window.jQuery=jquery']) => {
   return {
     test: path.resolve(javascripts, file),
     use: [
-      `imports-loader?${importsArr.join(',')}`,
+      // All govuk modules attach to window and so need window imported
+      `imports-loader?${['window=window', ...importsArr].join(',')}`,
       `exports-loader?${exposeArr.join(',')}`
     ]
   };

--- a/src/webpack.js
+++ b/src/webpack.js
@@ -33,6 +33,7 @@ const webpackSettings = (assetPath, settings) => {
       path: path.resolve('./dist'),
       filename: '[name].js'
     },
+    externals: [{ window: 'window' }],
     module: {
       rules: [
         ...browserSupport,


### PR DESCRIPTION
This PR ensures that govuk modules will actually use the real window rather than creating an empty object called window to attach themselves to. 

To do this we define window as an external which should be available and ensure that all govuk modules import the window by adding it as a dependency to it's `import-loader` declaration.
