### PR TITLE
Check your answers accessibility fixes

### DIFF
--- a/assets/scss/look-and-feel/check-your-answers.scss
+++ b/assets/scss/look-and-feel/check-your-answers.scss
@@ -5,6 +5,12 @@
     display: table;
   }
 
+  @include media(desktop) {
+    &:first-child > * {
+      padding-top: 0;
+    }
+  }
+
   > * {
     position: relative;
     border-bottom: 1px solid $border-colour;
@@ -25,12 +31,6 @@
         padding-right: em(20, 19);
         padding-bottom: em(9, 19);
         margin: 0;
-      }
-    }
-
-    @include media(desktop) {
-      &:first-child > * {
-        padding-top: 0;
       }
     }
   }

--- a/templates/look-and-feel/components/check-your-answers.njk
+++ b/templates/look-and-feel/components/check-your-answers.njk
@@ -1,27 +1,29 @@
 {% macro answer(question, answer, url, id) %}
-<div id="cya-{{ safeId(id, question) }}">
-  <dt class="cya-question">
-    {{ question }}
-  </dt>
-  <dd class="cya-answer">
-    {% if caller %}
-      {{ caller() }}
-    {% else %}
-      {% if isArray(answer) %}
-        <ul>
-          {% for line in answer %}
-            <li>{{ line }}</li>
-          {% endfor %}
-        </ul>
-      {% else %}
-        {{ answer }}
-      {% endif%}
-    {% endif %}
-  </dd>
-  <dd class="cya-change">
-    <a href="{{ url }}">
-      Change<span class="visually-hidden"> {{ question }}</span>
-    </a>
-  </dd>
+<div class="govuk-check-your-answers cya-questions-short">
+    <dl id="cya-{{ safeId(id, question) }}">
+      <dt class="cya-question">
+        {{ question }}
+      </dt>
+      <dd class="cya-answer">
+        {% if caller %}
+          {{ caller() }}
+        {% else %}
+          {% if isArray(answer) %}
+            <ul>
+              {% for line in answer %}
+                <li>{{ line }}</li>
+              {% endfor %}
+            </ul>
+          {% else %}
+            {{ answer }}
+          {% endif%}
+        {% endif %}
+      </dd>
+      <dd class="cya-change">
+        <a href="{{ url }}">
+          Change<span class="visually-hidden"> {{ question }}</span>
+        </a>
+      </dd>
+    </dl>
 </div>
 {% endmacro %}

--- a/templates/look-and-feel/layouts/check_your_answers.html
+++ b/templates/look-and-feel/layouts/check_your_answers.html
@@ -36,7 +36,6 @@
         {{ header(section.title, size='medium') }}
       {% endif %}
 
-      <dl class="govuk-check-your-answers cya-questions-short">
         {% for part in section.completedAnswers %}
           {% if not part.hide %}
             {% if part.html %}
@@ -46,7 +45,7 @@
             {% endif %}
           {% endif %}
         {% endfor %}
-      </dl>
+
     {% endif %}
   {% endfor %}
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1497,7 +1497,7 @@ deep-is@~0.1.3:
   version "0.1.3"
   resolved "https://registry.yarnpkg.com/deep-is/-/deep-is-0.1.3.tgz#b369d6fb5dbc13eecf524f91b070feedc357cf34"
 
-deepmerge@^2.0.0:
+deepmerge@2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/deepmerge/-/deepmerge-2.0.1.tgz#25c1c24f110fb914f80001b925264dd77f3f4312"
 


### PR DESCRIPTION
- This PR is to fix accessibility issues in the check-your-answers page. 
- There should be no `<div>` tag within a `<dl`> tag.
- The fix is to move the `<dl>` tag within `<div>` tag. This has been done within the check-your-answers macro. And so the `<dl>` tag has been removed from the check-your-answers layout.
- The SASS has been modified to reflect this change. There are no changes to be made within your own app unless you have a custom `answer.html` for an answer.