### PR TITLE
Various accessibility fixes

### DIFF
--- a/templates/look-and-feel/components/header.njk
+++ b/templates/look-and-feel/components/header.njk
@@ -3,12 +3,20 @@
     heading - (required) Main heading text
     section - (optional) Section text displayed above the heading
     size    - (default = 'xlarge') heading size
+    fieldsValidated - (default = false) Whether the fields have been validated or not
+    fieldsValid - (default = true) Whether the fields are valid or not
 
   When size is not xlarge or large the section will not be displayed as
   the size and lightness of the text would not be easily read.
+  When the fields on a page are not valid, the header element will change to a
+  h2 to comply with accessibility header rules as the error summary contains an h1 element
 #}
-{% macro header(heading, section='', size='xlarge') %}
-<h1 class="heading-{{ size }}">
+{% macro header(heading, section='', size='xlarge', fieldsValidated=false, fieldsValid=true) %}
+{% if fieldsValidated and not fieldsValid %}
+    <h2 class="heading-{{ size }}">
+{% else %}
+    <h1 class="heading-{{ size }}">
+{% endif %}
 {% if section != '' and (size == 'xlarge' or size == 'large') %}
   <span class="heading-secondary">
     {{ section }}

--- a/templates/look-and-feel/components/toggle_help.njk
+++ b/templates/look-and-feel/components/toggle_help.njk
@@ -11,7 +11,7 @@
 {% macro toggleHelp(link, text, id, openByDefault = false) %}
 
     <details role="group">
-        <summary role="button" aria-controls="{{ id }}" aria-expanded="{{ openByDefault.toString() }}">
+        <summary role="button" aria-expanded="{{ openByDefault.toString() }}">
             <span class="summary">{{ link }}</span></summary>
         <div class="panel panel-border-narrow" id="{{ id }}-0" aria-hidden="{{ not openByDefault.toString() }}">
             <p>

--- a/templates/look-and-feel/layouts/add_another.html
+++ b/templates/look-and-feel/layouts/add_another.html
@@ -25,7 +25,7 @@
 
     <dl class="add-another-list">
       {% for fieldName, item in fields.items.fields %}
-        {% call addAnotherItem(item, deleteUrl(loop.index0), editUrl(loop.index0)) %}
+        {% call addAnotherItem(item, deleteUrl(loop.index0), editUrl(loop.index0), loop.index) %}
           {% block item %}{{ item.value }}{% endblock %}
         {% endcall %}
       {% else %}
@@ -39,7 +39,7 @@
   {% endcall %}
 
   {% call formSection() %}
-    <a href="{{ addAnotherUrl }}" class="add-another-add-link">
+    <a href="{{ addAnotherUrl }}" class="add-another-add-link" role="button">
       {{ defaultContent.addAnotherLink }}
     </a>
   {% endcall %}
@@ -66,7 +66,7 @@
 
 
 {# Macro specific to this layout #}
-{% macro addAnotherItem(field, deleteUrl, editUrl, noItems=false) %}
+{% macro addAnotherItem(field, deleteUrl, editUrl, itemNumber, noItems=false) %}
   <dt class="visually-hidden">{% if field %} {{ safeId(field.id) }} {% endif %}</dt>
   <dd {% if field %} id="add-another-list-{{ safeId(field.id) }}" {% endif %} class="add-another-list-item {{ errorClass(field) }} {% if noItems %}noItems{% endif %}">
     {{ errorsFor(field) }}
@@ -75,10 +75,10 @@
   {% if deleteUrl or editUrl %}
     <dd class="add-another-list-controls">
       {% if editUrl %}
-        <a href="{{ editUrl }}" class="add-another-edit-link">Edit<span class="visually-hidden">{{ defaultContent.itemLabel }}</span></a>
+        <a href="{{ editUrl }}" class="add-another-edit-link">Edit<span class="visually-hidden">{{ defaultContent.itemLabel }} {{ itemNumber }}</span></a>
       {% endif %}
       {% if deleteUrl %}
-        <a href="{{ deleteUrl }}" class="add-another-delete-link">Delete<span class="visually-hidden">{{ defaultContent.itemLabel }}</span></a>
+        <a href="{{ deleteUrl }}" class="add-another-delete-link">Delete<span class="visually-hidden">{{ defaultContent.itemLabel }} {{ itemNumber }}</span></a>
       {% endif %}
     </dd>
   {% endif %}


### PR DESCRIPTION
- Accessibility issue 1 - Multiple `<h1`> elements when there are field errors and the error summary is visible. As the error summary contains an h1 and must appear above the header, the solution is to change the element of the header from `<h1>` to an `<h2>` when their are errors.

- Accessibility issue 2 - aria-controls is not valid ARIA attribute. Remove the attribute from the toggle help component.

- Accessibility issue 3 - Add another delete and edit links need to be more unique to know which one is to be deleted on edited. Passing the item number to the Add Another macro and adding it to the links but hidden. So it reads: `Delete reason for appealing 1` rather than `Delete reason for appealing`.

- Accessibility issue 4 - Add another link requires a role button attribute on it.