### PR TITLE
Selection buttons h1

### DIFF
--- a/templates/look-and-feel/components/fields.njk
+++ b/templates/look-and-feel/components/fields.njk
@@ -117,9 +117,9 @@
 
       <legend>
         {% if hideQuestion %}
-          <h1 class="visually-hidden heading-medium">{{ question }}</h1>
+          <h2 class="visually-hidden heading-medium">{{ question }}</h1>
         {% else %}
-          <h1 class="heading-medium">{{ question }}</h1>
+          <h2 class="heading-medium">{{ question }}</h1>
         {% endif %}
         {% if hint -%}
         <span class="body-text form-hint" id="{{ field.id }}-hint">


### PR DESCRIPTION
Change the selection Buttons legend to use an h2 rather than an h1 which fixes any accessibility issues where there are multiple h1s on a page