### PR TITLE
Revert hyphen to dot

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "express-nunjucks": "^2.2.3",
     "extract-text-webpack-plugin": "^3.0.0",
     "govuk-elements-sass": "^3.1.1",
+    "govuk_frontend_toolkit": "^8.1.0",
     "govuk_template_jinja": "^0.23.0",
     "imports-loader": "github:webpack-contrib/imports-loader#abea1c24f84b1343f9a277e33c8d89c83c013274",
     "jquery": "^3.2.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@hmcts/look-and-feel",
   "description": "One question per page apps made easy",
-  "version": "1.19.6",
+  "version": "2.0.0",
   "main": "./src/main.js",
   "dependencies": {
     "babel-core": "^6.26.0",

--- a/src/nunjucks.js
+++ b/src/nunjucks.js
@@ -29,11 +29,11 @@ const nunjucksDefaults = {
         .map(str => str.toString())
         .join('-')
         .toLowerCase()
-        // replace foo[1] to foo-1
-        .replace(/\[(\d{1,})\]/, '-$1')
+        // replace foo[1] to foo.1
+        .replace(/\[(\d{1,})\]/, '.$1')
         .replace(/[^A-Za-z0-9\s_-]/g, '')
-        // replace 'foo bar' to 'foo-bar'
-        .replace(/\s/g, '-');
+        // replace 'foo bar' to 'foo.bar'
+        .replace(/\s/g, '.');
     }
   }
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -2686,6 +2686,11 @@ govuk_frontend_toolkit@^7.1.0:
   resolved "https://registry.yarnpkg.com/govuk_frontend_toolkit/-/govuk_frontend_toolkit-7.4.2.tgz#67c0b386c2761272464322ed1fc22db38d69afc3"
   integrity sha1-Z8CzhsJ2EnJGQyLtH8Its41pr8M=
 
+govuk_frontend_toolkit@^8.1.0:
+  version "8.1.0"
+  resolved "https://registry.yarnpkg.com/govuk_frontend_toolkit/-/govuk_frontend_toolkit-8.1.0.tgz#b09e4bc9c1abe494dc37284b0e96b11210f56e0e"
+  integrity sha512-KzuMy+xhH/QKJHYJYS4p6ZiPg1CWSd4TKJFBFzngpVnk2tbvEvfAw/yLoRmzgukd/9V4d9oDSA4dIXRFb7XvDA==
+
 govuk_template_jinja@^0.23.0:
   version "0.23.0"
   resolved "https://registry.yarnpkg.com/govuk_template_jinja/-/govuk_template_jinja-0.23.0.tgz#9315ac403d1d85b01a62b7044cb95d8ec3e303a4"


### PR DESCRIPTION
# Description

[DIV-3794 - OPP - AddAnother is broken from our 4.X.X release](https://tools.hmcts.net/jira/browse/DIV-3794)

This PR reverts a change made a while ago to swap dots for hyphens for input names. This was due to a bug in GOVUK elements which has now been resolved.

The reason we are reverting is because the previous change from dots to hyphens broke the Add Another functionality of One Per Page