### PR TITLE
Enable forms to use the autocomplete attribute

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@hmcts/look-and-feel",
   "description": "One question per page apps made easy",
-  "version": "2.0.2",
+  "version": "2.1.0",
   "main": "./src/main.js",
   "dependencies": {
     "babel-core": "^6.26.0",

--- a/templates/look-and-feel/layouts/check_your_answers.html
+++ b/templates/look-and-feel/layouts/check_your_answers.html
@@ -62,7 +62,14 @@
       {{ header('Now send your application', size='medium') }}
       <p>{{ pageContent.statementOfTruth | default(defaultContent.statementOfTruth) }}</p>
     {% endblock %}
-    <form action="{{ postUrl | default(path if path else url) }}" method="post" class="form">
+    <form
+      action="{{ postUrl | default(path if path else url) }}"
+      method="post"
+      class="form"
+      {% if config.autocomplete %}
+        autocomplete="{{config.autocomplete}}"
+      {% endif %}
+    >
 
       {% block statement_of_truth_fields %}
         {{ hiddenInput(fields.statementOfTruth, value=true) }}

--- a/templates/look-and-feel/layouts/question.html
+++ b/templates/look-and-feel/layouts/question.html
@@ -18,7 +18,15 @@
 
 {{ header(title, size='large', fieldsValidated=fields.validated, fieldsValid=fields.valid) }}
 
-<form enctype="{{ enc_type | default('application/x-www-form-urlencoded') }}" action="{{ postUrl | default(path if path else url) }}" method="post" class="form">
+<form
+  enctype="{{ enc_type | default('application/x-www-form-urlencoded') }}"
+  action="{{ postUrl | default(path if path else url) }}"
+  method="post"
+  class="form"
+  {% if config.autocomplete %}
+    autocomplete="{{config.autocomplete}}"
+  {% endif %}
+>
 
   {% block fields -%}
   {%- endblock %}


### PR DESCRIPTION
Filling a form on a public computer with autocomplete on (default behaviour) will leave a trail of the date entered for future users. This PR enables a client application to explicitly set an autocomplete strategy.

For backwards compatibility, the default is 'off'.

![image](https://user-images.githubusercontent.com/35854/52476090-7ab03300-2b95-11e9-8652-be2e80570d4a.png)
