### PR TITLE
Add text reference styles

### DIFF
--- a/assets/scss/look-and-feel/text-reference.scss
+++ b/assets/scss/look-and-feel/text-reference.scss
@@ -1,0 +1,22 @@
+/*
+Text
+*/
+
+$module: "text";
+
+.#{$module} {
+
+  &-reference {
+    display: block;
+    margin-top: 10px;
+    margin-bottom: 0;
+    
+    &-number {
+      @include bold-24;
+      letter-spacing: 2px;
+      margin-top: 5px;
+    }
+    
+  }
+
+}

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@hmcts/look-and-feel",
   "description": "One question per page apps made easy",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "main": "./src/main.js",
   "dependencies": {
     "babel-core": "^6.26.0",


### PR DESCRIPTION
Adds the .text-reference and .text-reference-number styles used by Divorce Done and Submitted pages. A copy of the style from reform-pattern-library:
https://github.com/hmcts/reform-pattern-library/blob/master/app/sass/components/_components-text.scss