### PR TITLE
undo inadvertent change when reverting hyphen to dots

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@hmcts/look-and-feel",
   "description": "One question per page apps made easy",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "main": "./src/main.js",
   "dependencies": {
     "babel-core": "^6.26.0",

--- a/src/nunjucks.js
+++ b/src/nunjucks.js
@@ -29,11 +29,10 @@ const nunjucksDefaults = {
         .map(str => str.toString())
         .join('-')
         .toLowerCase()
-        // replace foo[1] to foo.1
-        .replace(/\[(\d{1,})\]/, '.$1')
-        .replace(/[^A-Za-z0-9\s_-]/g, '')
-        // replace 'foo bar' to 'foo.bar'
-        .replace(/\s/g, '.');
+        // replace foo[1] to foo-1
+        .replace(/\[(\d{1,})\]/, '-$1')
+        // replace 'foo bar' to 'foo-bar'
+        .replace(/\s/g, '-');
     }
   }
 };


### PR DESCRIPTION
This reverts an inadvertent change that was made when reverting the hyphen to dots https://github.com/hmcts/look-and-feel/pull/108