### PR TITLE
Error validation/notification should not be browser side, but the GOV…

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@hmcts/look-and-feel",
   "description": "One question per page apps made easy",
-  "version": "2.2.2",
+  "version": "2.2.3",
   "main": "./src/main.js",
   "dependencies": {
     "babel-core": "^6.26.0",

--- a/templates/look-and-feel/components/fields.njk
+++ b/templates/look-and-feel/components/fields.njk
@@ -239,8 +239,6 @@
            id="{{ field.day.id }}"
            type="number"
            pattern="[0-9]*"
-           min="1"
-           max="31"
            name="{{ field.day.id }}"
            {% if field.day.value %}value="{{ field.day.value }}"{% endif %}>
   </div>
@@ -251,8 +249,6 @@
            id="{{ field.month.id }}"
            type="number"
            pattern="[0-9]*"
-           min="1"
-           max="12"
            name="{{ field.month.id }}"
            {% if field.month.value %}value="{{ field.month.value }}"{% endif %}>
   </div>
@@ -263,8 +259,6 @@
            id="{{ field.year.id }}"
            type="number"
            pattern="[0-9]*"
-           min="1"
-           max="9999"
            name="{{ field.year.id }}"
            {% if field.year.value %}value="{{ field.year.value }}"{% endif %}>
   </div>


### PR DESCRIPTION
https://tools.hmcts.net/jira/browse/DIV-4471

Error validation/notification should not be browser side, but the GOV.UK elements standard instead- (https://design-system.service.gov.uk/components/error-message/)

Validations are added as part of One-per-page date function