### PR TITLE
Improvements for doc downloads, selectionButton & colours

### DIFF
--- a/assets/scss/look-and-feel/done-page.scss
+++ b/assets/scss/look-and-feel/done-page.scss
@@ -1,0 +1,3 @@
+.govuk-panel--confirmation {
+  background: govuk-colour("green") !important;
+}

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@hmcts/look-and-feel",
   "description": "One question per page apps made easy",
-  "version": "4.0.4",
+  "version": "4.0.5",
   "main": "./src/main.js",
   "dependencies": {
     "babel-core": "^6.26.0",

--- a/templates/look-and-feel/components/document-list.njk
+++ b/templates/look-and-feel/components/document-list.njk
@@ -12,7 +12,7 @@
       <ul class="govuk-list govuk-body govuk-!-font-size-16">
         {%- for document in documents -%}
           <li>
-            <a class="govuk-link" href="{{ document.uri }}" aria-label="This link will download the file {{ content[document.type] }} {{ document.fileType | upper }}" target="_blank">
+            <a class="govuk-link" href="{{ document.uri }}" aria-label="This link will download the file {{ content[document.type] }} {{ document.fileType | upper }}">
               <span class="govuk-download__icon" aria-hidden="true"><span class="visually-hidden">Download</span></span>{{ content[document.type] }} ({{ document.fileType | upper }})
             </a>
           </li>

--- a/templates/look-and-feel/components/fields.njk
+++ b/templates/look-and-feel/components/fields.njk
@@ -80,6 +80,7 @@
   {% set option_value = option.value or option.label|lower %}
   {% set option_disabled = option.disabled or false %}
   {% set option_description = option.description or false %}
+  {% set option_hint = option.hint or false %}
 
   {% set typeStyle = "govuk-radios" %}
   {% if type == 'checkbox' -%}
@@ -110,6 +111,11 @@
     {% if option.label -%}
       <label for="{{ field.id }}-{{ option_value }}" class="govuk-label {{ typeStyle }}__label">
         {{ option.label }}
+        {% if option_hint %}
+            <span class="govuk-hint">
+              {{ option.hint }}
+            </span>
+        {% endif %}
         {% if option_description %}
             <span class="choice-description">
               {{ option.description }}


### PR DESCRIPTION
A couple of minor improvements:

- Document downloads now don't open a new browser tab
- SelectButton can show a hint
- confirmation panel on done pages are now the correct color 